### PR TITLE
makes getDeployed a public function

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -191,7 +191,7 @@ export class RelayClient {
         );
     }
 
-    private async getDeployed(safe: string): Promise<boolean> {        
+    public async getDeployed(safe: string): Promise<boolean> {        
         const resp: GetDeployedResponse = await this.send(
             `${GET_DEPLOYED}`,
             GET,


### PR DESCRIPTION
Make getDeployed function public.

This is a very helpful utility function for builders to check if their browser wallet user already has a Safe wallet deployed.