### PR TITLE
Feat: using signTypedData in generic Safe transaction for improved signing UX

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { TypedData, TypedDataDomain } from "viem";
+
 export enum TransactionType {
     SAFE = "SAFE",
     SAFE_CREATE = "SAFE-CREATE"
@@ -103,4 +105,24 @@ export interface RelayerTransactionResponse {
 
 export interface GetDeployedResponse {
     deployed: boolean;
+}
+
+export interface SafeTransactionData {
+    to: string;
+    value: string;
+    data: string;
+    operation: OperationType;
+    safeTxGas: string;
+    baseGas: string;
+    gasPrice: string;
+    gasToken: string;
+    refundReceiver: string;
+    nonce: string;
+}
+
+export interface SafeMessageData {
+    primaryType: string;
+    domain: TypedDataDomain;
+    types: TypedData;
+    message: SafeTransactionData;
 }


### PR DESCRIPTION
### Before
<img width="396" height="527" alt="signing-before" src="https://github.com/user-attachments/assets/98e813f1-8f51-4cd3-bc33-ea413cf9146e" />

### After
<img width="455" height="977" alt="signing-after" src="https://github.com/user-attachments/assets/6a002154-87b9-4c9c-bf09-4220f771e758" />
