### PR TITLE
chore: upgrade axios to 1.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@polymarket/builder-abstract-signer": "0.0.1",
         "@polymarket/builder-signing-sdk": "^0.0.8",
-        "axios": "^0.27.2",
+        "axios": "^1.13.2",
         "browser-or-node": "^3.0.0",
         "ethers": "5.8.0",
         "tsx": "^4.20.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8
       axios:
-        specifier: ^0.27.2
-        version: 0.27.2
+        specifier: ^1.13.2
+        version: 1.13.2
       browser-or-node:
         specifier: ^3.0.0
         version: 3.0.0
@@ -445,11 +445,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-
-  axios@1.13.0:
-    resolution: {integrity: sha512-zt40Pz4zcRXra9CVV31KeyofwiNvAbJ5B6YPz9pMJ+yOSLikvPT4Yi5LjfgjRa9CawVYBaD1JQzIVcIvBejKeA==}
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -688,6 +685,10 @@ packages:
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   fs.realpath@1.0.0:
@@ -1550,7 +1551,7 @@ snapshots:
   '@polymarket/builder-signing-sdk@0.0.8':
     dependencies:
       '@types/node': 18.19.130
-      axios: 1.13.0
+      axios: 1.13.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - debug
@@ -1634,17 +1635,10 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@0.27.2:
+  axios@1.13.2:
     dependencies:
       follow-redirects: 1.15.11
-      form-data: 4.0.4
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.13.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -1908,6 +1902,14 @@ snapshots:
   follow-redirects@1.15.11: {}
 
   form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
-import { Wallet } from "@ethersproject/wallet";
-import { JsonRpcSigner } from "@ethersproject/providers";
+import { Wallet, providers } from "ethers";
 import { WalletClient, zeroAddress } from "viem";
+
+type JsonRpcSigner = InstanceType<typeof providers.JsonRpcSigner>;
 import { createAbstractSigner, IAbstractSigner } from "@polymarket/builder-abstract-signer";
 import {
     GET,

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestHeaders, AxiosResponse } from "axios";
+import axios, { AxiosInstance, RawAxiosRequestHeaders, AxiosResponse } from "axios";
 
 export const GET = "GET";
 export const POST = "POST";
@@ -9,7 +9,7 @@ export const PUT = "PUT";
 export type QueryParams = Record<string, any>;
 
 export interface RequestOptions {
-    headers?: AxiosRequestHeaders;
+    headers?: RawAxiosRequestHeaders;
     data?: any;
     params?: QueryParams;
 }


### PR DESCRIPTION
## Summary
- Upgrades axios from 0.27.2 to 1.13.2
- Fixes 3 security vulnerabilities (2 high severity, 1 moderate severity)
- Updates type imports for axios 1.x compatibility
- Fixes ethers type imports

## Security Fixes
- **HIGH**: DoS attack through lack of data size check (GHSA-4hjh-wcwx-xvwj)
- **HIGH**: SSRF and credential leakage via absolute URL (GHSA-jr5f-v2jv-69x6)
- **MODERATE**: Cross-Site Request Forgery vulnerability (GHSA-wf5p-g6vw-rhxx)

## Changes
- Updated `package.json` axios dependency to `^1.13.2`
- Changed `AxiosRequestHeaders` to `RawAxiosRequestHeaders` in `src/http-helpers/index.ts` for type compatibility
- Fixed ethers imports in `src/client.ts` to use type alias for `JsonRpcSigner`
