### PR TITLE
fix: move `builder-signing-sdk` to peerDependencies to avoid duplicate instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ TypeScript client library for interacting with Polymarket relayer infrastructure
 ## Installation
 
 ```bash
-pnpm install @polymarket/builder-relayer-client
+pnpm install @polymarket/builder-relayer-client @polymarket/builder-signing-sdk
 ```
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/builder-relayer-client",
     "description": "Client for Polymarket relayers",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
@@ -30,9 +30,11 @@
         "tslib": "^2.8.1",
         "ws": "^8.11.0"
     },
+    "peerDependencies": {
+        "@polymarket/builder-signing-sdk": ">=0.0.8"
+    },
     "dependencies": {
         "@polymarket/builder-abstract-signer": "0.0.1",
-        "@polymarket/builder-signing-sdk": "^0.0.8",
         "axios": "^0.27.2",
         "browser-or-node": "^3.0.0",
         "ethers": "5.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@polymarket/builder-signing-sdk':
-        specifier: ^0.0.8
+        specifier: '>=0.0.8'
         version: 0.0.8
       axios:
         specifier: ^0.27.2


### PR DESCRIPTION
## Background

When a project installs both `@polymarket/builder-relayer-client@0.0.8` and `@polymarket/builder-signing-sdk@1.0.0`, TypeScript compilation fails with **TS2345** when passing a `BuilderConfig` instance to `RelayClient`.

## Root Cause

`builder-relayer-client` declares `"@polymarket/builder-signing-sdk": "^0.0.8"` in `dependencies`. Under semver, `^0.0.8` resolves to `>=0.0.8 <0.0.9`, which does **not** cover `1.0.0`. When the consumer also depends on `builder-signing-sdk@1.0.0`, the package manager installs two separate copies (0.0.8 and 1.0.0). Because `BuilderConfig` uses a `private ensureValid` field, TypeScript treats the two copies as nominally distinct types, causing the type mismatch error.

## Solution

- Move `@polymarket/builder-signing-sdk` from `dependencies` to `peerDependencies` with range `>=0.0.8`, covering both 0.0.x and 1.0.0+.
- This ensures only a single copy exists at runtime — the one the consumer installs — eliminating the duplicate type issue.
- Bump version to `0.0.9`.
- Update README installation command to include the peer dependency.

## Changed Files

- `package.json` — remove from `dependencies`, add to `peerDependencies`, bump version
- `pnpm-lock.yaml` — regenerated
- `README.md` — update install command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes packaging/dependency resolution for consumers, which can break installs/builds if the peer dependency isn’t provided or resolves to an incompatible version.
> 
> **Overview**
> **Shifts `@polymarket/builder-signing-sdk` from `dependencies` to `peerDependencies` (range `>=0.0.8`)** to avoid duplicate installed copies that can cause TypeScript type mismatches.
> 
> Bumps the library version to `0.0.9`, updates the README install command to include the required peer, and adjusts the lockfile to match the new dependency specifier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c078e0e5ba7f33fe41d2d95b4866fd884db72455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->