### PR TITLE
fix: correct runtime dependency declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,17 +27,19 @@
         "prettier": "^2.7.1",
         "ts-node": "^9.1.1",
         "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
+        "tsx": "^4.20.3",
+        "typescript": "^5.8.3",
         "ws": "^8.11.0"
     },
     "dependencies": {
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
         "@polymarket/builder-abstract-signer": "0.0.1",
         "@polymarket/builder-signing-sdk": "^0.0.8",
         "axios": "^0.27.2",
         "browser-or-node": "^3.0.0",
         "ethers": "5.8.0",
-        "tsx": "^4.20.3",
-        "typescript": "^5.8.3",
+        "tslib": "^2.8.1",
         "viem": "^2.31.4"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@ethersproject/providers':
+        specifier: 5.8.0
+        version: 5.8.0
+      '@ethersproject/wallet':
+        specifier: 5.8.0
+        version: 5.8.0
       '@polymarket/builder-abstract-signer':
         specifier: 0.0.1
         version: 0.0.1
@@ -23,12 +29,9 @@ importers:
       ethers:
         specifier: 5.8.0
         version: 5.8.0
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.6
-      typescript:
-        specifier: ^5.8.3
-        version: 5.9.3
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
       viem:
         specifier: ^2.31.4
         version: 2.38.5(typescript@5.9.3)
@@ -75,9 +78,12 @@ importers:
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.6
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
       ws:
         specifier: ^8.11.0
         version: 8.18.3


### PR DESCRIPTION
## Summary

- Move `tslib` from `devDependencies` to `dependencies` — `tsconfig.json` has `importHelpers: true`, so the compiled output emits `require("tslib")`. Consumers hit `MODULE_NOT_FOUND` at runtime because `tslib` was only a devDependency and not installed alongside the package.
  - This bug was previously masked by `@polymarket/builder-signing-sdk@0.0.8`, which happened to pull in `tslib` transitively. After upgrading `signing-sdk` to `1.0.0` (which dropped its `tslib` dependency), the error surfaced.
- Move `tsx` and `typescript` from `dependencies` to `devDependencies` — they are build-time tools and should not be shipped as runtime dependencies.
- Add `@ethersproject/providers` and `@ethersproject/wallet` as explicit `dependencies` — `src/client.ts` imports them directly, but under pnpm's strict mode they are not accessible as implicit sub-dependencies of `ethers`.

## Test plan

- [x] `make build` compiles successfully
- [x] `dist/index.js` contains `require("tslib")` call
- [x] `tslib` appears in `dependencies` in the final `package.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change; main impact is installation/runtime behavior if consumers relied on previous (incorrect) transitive deps.
> 
> **Overview**
> Fixes package dependency declarations to match actual runtime requirements. Moves `tslib` into `dependencies` (it’s required by compiled output) and moves build-time tooling (`tsx`, `typescript`) into `devDependencies`.
> 
> Also adds `@ethersproject/providers` and `@ethersproject/wallet` as explicit `dependencies` to align with direct imports and avoid strict package manager resolution issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ac5569ae208b3df605c19e570a1f742deb35b6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->