### PR TITLE
ft: add deposit wallet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ const proxyClient = new RelayClient(relayerUrl, chainId, wallet, undefined, Rela
 
 The client supports two transaction types via the `RelayerTxType` enum:
 
-- **`RelayerTxType.SAFE`** (default): Executes transactions through for a Gnosis Safe
+- **`RelayerTxType.SAFE`** (default): Executes transactions through a Gnosis Safe
 - **`RelayerTxType.PROXY`**: Executes transactions for a Polymarket Proxy wallet
 
 The transaction type is specified as the last parameter when creating a `RelayClient` instance. All examples use the `Transaction` type - the client automatically converts transactions to the appropriate format (`SafeTransaction` or `ProxyTransaction`) based on the `RelayerTxType` you've configured.
+
+The client also supports **Deposit Wallets**, which use separate dedicated methods rather than the `execute()` flow. See [Deposit Wallet](#deposit-wallet) below.
 
 ### With Local Builder Authentication
 
@@ -307,4 +309,111 @@ console.log("Safe redeem completed:", safeResult.transactionHash);
 const proxyResponse = await proxyClient.execute([redeemTx], "redeem positions");
 const proxyResult = await proxyResponse.wait();
 console.log("Proxy redeem completed:", proxyResult.transactionHash);
+```
+
+### Deposit Wallet
+
+Deposit Wallets are UUPS-upgradeable smart contract wallets that support EIP-712 signed batch execution. Unlike Safe and Proxy wallets which use the `execute()` method, Deposit Wallets have dedicated methods.
+
+#### Derive Deposit Wallet Address
+
+You can predict the deposit wallet address before deployment using CREATE2:
+
+```typescript
+const client = new RelayClient(relayerUrl, chainId, wallet, builderConfig);
+
+const walletAddress = await client.deriveDepositWalletAddress();
+console.log("Expected deposit wallet address:", walletAddress);
+```
+
+Or use the standalone function directly:
+
+```typescript
+import { deriveDepositWallet } from "@polymarket/builder-relayer-client";
+
+const walletAddress = deriveDepositWallet(ownerAddress, factoryAddress, implementationAddress);
+```
+
+#### Deploy Deposit Wallet
+
+```typescript
+const client = new RelayClient(relayerUrl, chainId, wallet, builderConfig);
+
+const response = await client.deployDepositWallet();
+const result = await response.wait();
+
+if (result) {
+  console.log("Deposit wallet deployed successfully!");
+  console.log("Transaction Hash:", result.transactionHash);
+} else {
+  console.log("Deposit wallet deployment failed");
+}
+```
+
+#### Execute Deposit Wallet Batch
+
+Deposit wallet transactions use `DepositWalletCall` instead of `Transaction`. Each call has a `target` (instead of `to`), `value`, and `data` field. Batches require a `walletAddress` and a `deadline` (unix timestamp for signature expiry).
+
+```typescript
+import { encodeFunctionData, prepareEncodeFunctionData, maxUint256 } from "viem";
+import { DepositWalletCall } from "@polymarket/builder-relayer-client";
+
+const erc20Abi = [
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "_spender", "type": "address"},
+      {"name": "_value", "type": "uint256"}
+    ],
+    "name": "approve",
+    "outputs": [{"name": "", "type": "bool"}],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+];
+
+const erc20 = prepareEncodeFunctionData({
+  abi: erc20Abi,
+  functionName: "approve",
+});
+
+function createApproveCall(
+  tokenAddress: string,
+  spenderAddress: string
+): DepositWalletCall {
+  const calldata = encodeFunctionData({
+    ...erc20,
+    args: [spenderAddress, maxUint256]
+  });
+  return {
+    target: tokenAddress,
+    value: "0",
+    data: calldata,
+  };
+}
+
+const client = new RelayClient(relayerUrl, chainId, wallet, builderConfig);
+
+const walletAddress = await client.deriveDepositWalletAddress();
+
+const approveCall = createApproveCall(
+  "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174", // USDC
+  "0x4d97dcd97ec945f40cf65f87097ace5ea0476045"  // CTF
+);
+
+// Deadline: 4 minutes from now
+const deadline = Math.floor(Date.now() / 1000 + 240).toString();
+
+const response = await client.executeDepositWalletBatch([approveCall], walletAddress, deadline);
+const result = await response.wait();
+console.log("Deposit wallet batch executed:", result.transactionHash);
+```
+
+#### Check Deposit Wallet Deployment
+
+```typescript
+const walletAddress = await client.deriveDepositWalletAddress();
+const isDeployed = await client.getDeployed(walletAddress, "WALLET");
+console.log("Deposit wallet deployed:", isDeployed);
 ```

--- a/examples/deployDepositWallet.ts
+++ b/examples/deployDepositWallet.ts
@@ -1,0 +1,43 @@
+import { config as dotenvConfig } from "dotenv";
+import { resolve } from "path";
+import { RelayClient } from "../src/client";
+import { BuilderApiKeyCreds, BuilderConfig } from "@polymarket/builder-signing-sdk";
+import { privateKeyToAccount } from "viem/accounts";
+import { createWalletClient, Hex, http } from "viem";
+import { polygon } from "viem/chains";
+
+dotenvConfig({ path: resolve(__dirname, "../.env") });
+
+async function main() {
+    console.log(`Starting...`);
+
+    const relayerUrl = `${process.env.RELAYER_URL}`;
+    const chainId = parseInt(`${process.env.CHAIN_ID}`);
+    const pk = privateKeyToAccount(`${process.env.PK}` as Hex);
+    const wallet = createWalletClient({account: pk, chain: polygon, transport: http(`${process.env.RPC_URL}`)});
+
+    const builderCreds: BuilderApiKeyCreds = {
+        key: `${process.env.BUILDER_API_KEY}`,
+        secret: `${process.env.BUILDER_SECRET}`,
+        passphrase: `${process.env.BUILDER_PASS_PHRASE}`,
+    };
+
+    const builderConfig = new BuilderConfig({
+        localBuilderCreds: builderCreds
+    });
+
+    const client = new RelayClient(relayerUrl, chainId, wallet, builderConfig);
+
+    // Derive the expected deposit wallet address before deployment
+    const expectedAddress = await client.deriveDepositWalletAddress();
+    console.log(`Expected deposit wallet address: ${expectedAddress}`);
+
+    // Deploy the deposit wallet
+    const resp = await client.deployDepositWallet();
+    const res = await resp.wait();
+
+    console.log(res);
+    console.log(`Done!`);
+}
+
+main();

--- a/examples/executeDepositWallet.ts
+++ b/examples/executeDepositWallet.ts
@@ -1,0 +1,79 @@
+import { config as dotenvConfig } from "dotenv";
+import { resolve } from "path";
+import { RelayClient, DepositWalletCall } from "../src";
+import { BuilderApiKeyCreds, BuilderConfig } from "@polymarket/builder-signing-sdk";
+import { privateKeyToAccount } from "viem/accounts";
+import { createWalletClient, encodeFunctionData, Hex, http, maxUint256, prepareEncodeFunctionData } from "viem";
+import { polygon } from "viem/chains";
+
+dotenvConfig({ path: resolve(__dirname, "../.env") });
+
+const erc20Abi = [
+    {
+        "constant": false,"inputs":
+        [{"name": "_spender","type": "address"},{"name": "_value","type": "uint256"}],
+        "name": "approve",
+        "outputs": [{"name": "","type": "bool"}],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+];
+
+const erc20 = prepareEncodeFunctionData({
+    abi: erc20Abi,
+    functionName: "approve",
+});
+
+function createApproveCall(
+    token: string,
+    spender: string,
+): DepositWalletCall {
+    const calldata = encodeFunctionData({...erc20, args: [spender, maxUint256]});
+    return {
+        target: token,
+        value: "0",
+        data: calldata,
+    };
+}
+
+async function main() {
+    console.log(`Starting...`);
+
+    const relayerUrl = `${process.env.RELAYER_URL}`;
+    const chainId = parseInt(`${process.env.CHAIN_ID}`);
+    const pk = privateKeyToAccount(`${process.env.PK}` as Hex);
+    const wallet = createWalletClient({account: pk, chain: polygon, transport: http(`${process.env.RPC_URL}`)});
+
+    const builderCreds: BuilderApiKeyCreds = {
+        key: `${process.env.BUILDER_API_KEY}`,
+        secret: `${process.env.BUILDER_SECRET}`,
+        passphrase: `${process.env.BUILDER_PASS_PHRASE}`,
+    };
+
+    const builderConfig = new BuilderConfig({
+        localBuilderCreds: builderCreds
+    });
+
+    const client = new RelayClient(relayerUrl, chainId, wallet, builderConfig);
+
+    const walletAddress = `${process.env.DEPOSIT_WALLET_ADDRESS}`;
+
+    const usdc = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+    const ctf = "0x4d97dcd97ec945f40cf65f87097ace5ea0476045";
+
+    // Build calls
+    const approveCall = createApproveCall(usdc, ctf);
+
+    // Deadline: 4 minutes from now
+    const deadline = Math.floor(Date.now() / 1000 + 240).toString();
+
+    // Execute batch on deposit wallet
+    const resp = await client.executeDepositWalletBatch([approveCall], walletAddress, deadline);
+    const res = await resp.wait();
+
+    console.log(res);
+    console.log(`Done!`);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/builder-relayer-client",
     "description": "Client for Polymarket relayers",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [

--- a/src/abis/depositWallet.ts
+++ b/src/abis/depositWallet.ts
@@ -1,0 +1,9 @@
+export const depositWalletV1Abi = [
+    {
+        inputs: [],
+        name: "nonce",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+] as const;

--- a/src/abis/index.ts
+++ b/src/abis/index.ts
@@ -3,3 +3,4 @@ export * from "./proxyFactory";
 export  * from "./erc20Abi";
 export * from "./safe";
 export  * from "./multisend";
+export * from "./depositWallet";

--- a/src/builder/deposit-wallet.ts
+++ b/src/builder/deposit-wallet.ts
@@ -1,0 +1,93 @@
+import { Hex } from "viem";
+import { IAbstractSigner } from "@polymarket/builder-abstract-signer";
+import { DEPOSIT_WALLET_DOMAIN_NAME, DEPOSIT_WALLET_DOMAIN_VERSION } from "../constants";
+import { DepositWalletContractConfig } from "../config";
+import {
+    DepositWalletBatchRequest,
+    DepositWalletCall,
+    DepositWalletCreateRequest,
+    DepositWalletTransactionArgs,
+    TransactionType,
+} from "../types";
+
+const DEPOSIT_WALLET_TYPES = {
+    Call: [
+        { name: "target", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "data", type: "bytes" },
+    ],
+    Batch: [
+        { name: "wallet", type: "address" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+        { name: "calls", type: "Call[]" },
+    ],
+};
+
+async function signBatch(
+    signer: IAbstractSigner,
+    chainId: number,
+    walletAddress: string,
+    nonce: string,
+    deadline: string,
+    calls: DepositWalletCall[],
+): Promise<string> {
+    const domain = {
+        name: DEPOSIT_WALLET_DOMAIN_NAME,
+        version: DEPOSIT_WALLET_DOMAIN_VERSION,
+        chainId,
+        verifyingContract: walletAddress as Hex,
+    };
+
+    const message = {
+        wallet: walletAddress,
+        nonce: BigInt(nonce),
+        deadline: BigInt(deadline),
+        calls: calls.map(c => ({
+            target: c.target,
+            value: BigInt(c.value),
+            data: c.data,
+        })),
+    };
+
+    return signer.signTypedData(domain, DEPOSIT_WALLET_TYPES, message, "Batch");
+}
+
+export async function buildDepositWalletBatchRequest(
+    signer: IAbstractSigner,
+    args: DepositWalletTransactionArgs,
+    config: DepositWalletContractConfig,
+): Promise<DepositWalletBatchRequest> {
+    const signature = await signBatch(
+        signer,
+        args.chainId,
+        args.walletAddress,
+        args.nonce,
+        args.deadline,
+        args.calls,
+    );
+
+    return {
+        type: TransactionType.WALLET,
+        from: args.from,
+        to: config.DepositWalletFactory,
+        nonce: args.nonce,
+        signature,
+        depositWalletParams: {
+            depositWallet: args.walletAddress,
+            deadline: args.deadline,
+            calls: args.calls,
+        },
+    };
+}
+
+export function buildDepositWalletCreateRequest(
+    from: string,
+    config: DepositWalletContractConfig,
+): DepositWalletCreateRequest {
+    return {
+        type: TransactionType.WALLET_CREATE,
+        from,
+        to: config.DepositWalletFactory,
+    };
+}

--- a/src/builder/derive.ts
+++ b/src/builder/derive.ts
@@ -1,4 +1,4 @@
-import { keccak256, getCreate2Address, encodePacked, Hex, encodeAbiParameters } from 'viem'
+import { keccak256, getCreate2Address, encodePacked, Hex, encodeAbiParameters, Address, concat, pad, toHex } from 'viem'
 import { SAFE_INIT_CODE_HASH, PROXY_INIT_CODE_HASH } from "../constants";
 
 export const deriveProxyWallet = (address: string, proxyFactory: string): string => {
@@ -16,3 +16,51 @@ export const deriveSafe = (address: string, safeFactory: string) : string => {
         salt: keccak256(encodeAbiParameters([{ name: 'address', type: 'address' }], [address as Hex]))}
     );
 }
+
+/**
+ * Byte constants from Solady v0.1.26 LibClone.initCodeHashERC1967.
+ * These encode the minimal ERC-1967 proxy runtime bytecode.
+ */
+const ERC1967_CONST1: Hex = "0xcc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3";
+const ERC1967_CONST2: Hex = "0x5155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076";
+const ERC1967_PREFIX = 0x61003d3d8160233d3973n;
+
+/**
+ * Replicates Solady LibClone.initCodeHashERC1967(implementation, args).
+ * Hash of: prefix(10) | implementation(20) | 0x6009(2) | const2(32) | const1(32) | args(n)
+ */
+function initCodeHashERC1967(implementation: Address, args: Hex): Hex {
+    const n = BigInt((args.length - 2) / 2);
+    const combined = ERC1967_PREFIX + (n << 56n);
+
+    return keccak256(
+        concat([
+            toHex(combined, { size: 10 }),
+            implementation as Hex,
+            "0x6009",
+            ERC1967_CONST2,
+            ERC1967_CONST1,
+            args,
+        ]),
+    );
+}
+
+/**
+ * Computes the deterministic deposit wallet address for a given owner.
+ * walletId is derived as bytes32(owner) - the 20-byte address left-padded to 32 bytes.
+ */
+export const deriveDepositWallet = (
+    owner: string,
+    factory: string,
+    implementation: string,
+): string => {
+    const walletId = pad(owner as Hex, { dir: "left", size: 32 });
+    const args = encodeAbiParameters(
+        [{ type: "address" }, { type: "bytes32" }],
+        [factory as Address, walletId],
+    );
+    const salt = keccak256(args);
+    const bytecodeHash = initCodeHashERC1967(implementation as Address, args);
+
+    return getCreate2Address({ from: factory as Hex, salt, bytecodeHash });
+};

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -2,3 +2,4 @@ export * from "./safe";
 export * from "./create";
 export * from "./derive";
 export * from "./proxy";
+export * from "./deposit-wallet";

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,8 +8,10 @@ import {
     HttpClient,
     RequestOptions,
 } from "./http-helpers";
-import { 
+import {
     CallType,
+    DepositWalletCall,
+    DepositWalletTransactionArgs,
     GetDeployedResponse,
     NoncePayload,
     OperationType,
@@ -33,15 +35,18 @@ import {
     GET_TRANSACTIONS,
     SUBMIT_TRANSACTION,
 } from "./endpoints";
-import { 
+import {
     buildSafeTransactionRequest,
     buildSafeCreateTransactionRequest,
     buildProxyTransactionRequest,
+    buildDepositWalletBatchRequest,
+    buildDepositWalletCreateRequest,
     deriveSafe,
+    deriveDepositWallet,
 } from "./builder";
 import { sleep } from "./utils";
 import { ClientRelayerTransactionResponse } from "./response";
-import { ContractConfig, getContractConfig, isProxyContractConfigValid, isSafeContractConfigValid } from "./config";
+import { ContractConfig, getContractConfig, isProxyContractConfigValid, isSafeContractConfigValid, isDepositWalletContractConfigValid } from "./config";
 import { BuilderConfig, BuilderHeaderPayload } from "@polymarket/builder-signing-sdk";
 import { CONFIG_UNSUPPORTED_ON_CHAIN, SAFE_DEPLOYED, SAFE_NOT_DEPLOYED, SIGNER_UNAVAILABLE } from "./errors";
 import { encodeProxyTransactionData } from "./encode";
@@ -282,13 +287,101 @@ export class RelayClient {
         );
     }
 
-    public async getDeployed(safe: string): Promise<boolean> {        
+    public async getDeployed(address: string, type?: string): Promise<boolean> {
+        const params: Record<string, string> = { address };
+        if (type !== undefined) {
+            params.type = type;
+        }
         const resp: GetDeployedResponse = await this.send(
             `${GET_DEPLOYED}`,
             GET,
-            {params: { address: safe }},
+            {params},
         );
         return resp.deployed;
+    }
+
+    /**
+     * Deploys a new deposit wallet
+     * @returns
+     */
+    public async deployDepositWallet(): Promise<RelayerTransactionResponse> {
+        this.signerNeeded();
+        const from = await (this.signer as IAbstractSigner).getAddress();
+
+        const depositWalletConfig = this.contractConfig.DepositWalletContracts;
+        if (!isDepositWalletContractConfigValid(depositWalletConfig)) {
+            throw CONFIG_UNSUPPORTED_ON_CHAIN;
+        }
+
+        const request = buildDepositWalletCreateRequest(from, depositWalletConfig);
+        const requestPayload = JSON.stringify(request);
+
+        const resp: RelayerTransactionResponse = await this.sendAuthedRequest(POST, SUBMIT_TRANSACTION, requestPayload);
+        return new ClientRelayerTransactionResponse(
+            resp.transactionID,
+            resp.state,
+            resp.transactionHash,
+            this,
+        );
+    }
+
+    /**
+     * Executes a batch of calls on a deposit wallet
+     * @param calls - Array of calls to execute
+     * @param walletAddress - Address of the deposit wallet
+     * @param deadline - Unix timestamp deadline for the batch signature
+     * @returns
+     */
+    public async executeDepositWalletBatch(
+        calls: DepositWalletCall[],
+        walletAddress: string,
+        deadline: string,
+    ): Promise<RelayerTransactionResponse> {
+        this.signerNeeded();
+        const from = await (this.signer as IAbstractSigner).getAddress();
+
+        const depositWalletConfig = this.contractConfig.DepositWalletContracts;
+        if (!isDepositWalletContractConfigValid(depositWalletConfig)) {
+            throw CONFIG_UNSUPPORTED_ON_CHAIN;
+        }
+
+        const noncePayload = await this.getNonce(from, TransactionType.WALLET);
+
+        const args: DepositWalletTransactionArgs = {
+            from,
+            chainId: this.chainId,
+            walletAddress,
+            nonce: noncePayload.nonce,
+            deadline,
+            calls,
+        };
+
+        const request = await buildDepositWalletBatchRequest(
+            this.signer as IAbstractSigner,
+            args,
+            depositWalletConfig,
+        );
+
+        const requestPayload = JSON.stringify(request);
+
+        const resp: RelayerTransactionResponse = await this.sendAuthedRequest(POST, SUBMIT_TRANSACTION, requestPayload);
+        return new ClientRelayerTransactionResponse(
+            resp.transactionID,
+            resp.state,
+            resp.transactionHash,
+            this,
+        );
+    }
+
+    /**
+     * Derives the expected deposit wallet address for the current signer
+     * @returns The predicted deposit wallet address
+     */
+    public async deriveDepositWalletAddress(): Promise<string> {
+        this.signerNeeded();
+        const address = await (this.signer as IAbstractSigner).getAddress();
+        const config = this.contractConfig.DepositWalletContracts;
+        return deriveDepositWallet(address, config.DepositWalletFactory, config.DepositWalletImplementation);
     }
 
     /**
@@ -296,12 +389,12 @@ export class RelayClient {
      * Returns the relayer transaction if it does each the desired state
      * Returns undefined if the transaction hits the failed state
      * Times out after maxPolls is reached
-     * @param transactionId 
-     * @param states 
+     * @param transactionId
+     * @param states
      * @param failState
-     * @param maxPolls 
-     * @param pollFrequency 
-     * @returns 
+     * @param maxPolls
+     * @param pollFrequency
+     * @returns
      */
     public async pollUntilState(transactionId: string, states: string[], failState?: string, maxPolls?: number, pollFrequency?: number): Promise<RelayerTransaction | undefined> {
         console.log(`Waiting for transaction ${transactionId} matching states: ${states}...`)

--- a/src/client.ts
+++ b/src/client.ts
@@ -379,8 +379,11 @@ export class RelayClient {
      */
     public async deriveDepositWalletAddress(): Promise<string> {
         this.signerNeeded();
-        const address = await (this.signer as IAbstractSigner).getAddress();
         const config = this.contractConfig.DepositWalletContracts;
+        if (!isDepositWalletContractConfigValid(config)) {
+            throw CONFIG_UNSUPPORTED_ON_CHAIN;
+        }
+        const address = await (this.signer as IAbstractSigner).getAddress();
         return deriveDepositWallet(address, config.DepositWalletFactory, config.DepositWalletImplementation);
     }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,9 +8,15 @@ export interface SafeContractConfig {
     SafeMultisend: string;
 }
 
+export interface DepositWalletContractConfig {
+    DepositWalletFactory: string;
+    DepositWalletImplementation: string;
+}
+
 export interface ContractConfig {
     ProxyContracts: ProxyContractConfig;
     SafeContracts: SafeContractConfig;
+    DepositWalletContracts: DepositWalletContractConfig;
 };
 
 const AMOY: ContractConfig = {
@@ -22,7 +28,11 @@ const AMOY: ContractConfig = {
     SafeContracts: {
         SafeFactory: "0xaacFeEa03eb1561C4e67d661e40682Bd20E3541b",
         SafeMultisend: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
-    }
+    },
+    DepositWalletContracts: {
+        DepositWalletFactory: "0x00000000000Fb5C9ADea0298D729A0CB3823Cc07",
+        DepositWalletImplementation: "0x50a88fE9a441cB4c9c2aD6A2207CE2795C7D7Fbd",
+    },
 };
 
 const POL: ContractConfig = {
@@ -33,7 +43,11 @@ const POL: ContractConfig = {
     SafeContracts: {
         SafeFactory: "0xaacFeEa03eb1561C4e67d661e40682Bd20E3541b",
         SafeMultisend: "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
-    }
+    },
+    DepositWalletContracts: {
+        DepositWalletFactory: "0x00000000000Fb5C9ADea0298D729A0CB3823Cc07",
+        DepositWalletImplementation: "0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB",
+    },
 };
 
 export function isProxyContractConfigValid(
@@ -46,6 +60,12 @@ export function isSafeContractConfigValid(
     config: SafeContractConfig
 ): boolean {
     return !!config.SafeFactory && !!config.SafeMultisend;
+}
+
+export function isDepositWalletContractConfigValid(
+    config: DepositWalletContractConfig
+): boolean {
+    return !!config.DepositWalletFactory && !!config.DepositWalletImplementation;
 }
 
 export const getContractConfig = (chainId: number): ContractConfig => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,3 +3,6 @@ export const SAFE_INIT_CODE_HASH = "0x2bce2127ff07fb632d16c8347c4ebf501f4841168b
 export const PROXY_INIT_CODE_HASH = "0xd21df8dc65880a8606f09fe0ce3df9b8869287ab0b058be05aa9e8af6330a00b";
 
 export const SAFE_FACTORY_NAME = "Polymarket Contract Proxy Factory";
+
+export const DEPOSIT_WALLET_DOMAIN_NAME = "DepositWallet";
+export const DEPOSIT_WALLET_DOMAIN_VERSION = "1";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./client";
+export * from "./builder";
 export * from "./encode";
 export * from "./types";
 export * from "./response";

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,9 @@ export enum RelayerTxType {
 export enum TransactionType {
     SAFE = "SAFE",
     PROXY = "PROXY",
-    SAFE_CREATE = "SAFE-CREATE"
+    SAFE_CREATE = "SAFE-CREATE",
+    WALLET = "WALLET",
+    WALLET_CREATE = "WALLET-CREATE",
 }
 
 export interface SignatureParams {
@@ -153,4 +155,42 @@ export interface RelayerTransactionResponse {
 
 export interface GetDeployedResponse {
     deployed: boolean;
+}
+
+// Deposit Wallet types
+
+export interface DepositWalletCall {
+    target: string;
+    value: string;
+    data: string;
+}
+
+export interface DepositWalletTransactionArgs {
+    from: string;
+    chainId: number;
+    walletAddress: string;
+    nonce: string;
+    deadline: string;
+    calls: DepositWalletCall[];
+}
+
+export interface DepositWalletParams {
+    depositWallet: string;
+    deadline: string;
+    calls: DepositWalletCall[];
+}
+
+export interface DepositWalletBatchRequest {
+    type: string;
+    from: string;
+    to: string;
+    nonce: string;
+    signature: string;
+    depositWalletParams: DepositWalletParams;
+}
+
+export interface DepositWalletCreateRequest {
+    type: string;
+    from: string;
+    to: string;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new transaction types and EIP-712 signing/CREATE2 derivation for Deposit Wallet flows, plus changes the `getDeployed` API signature; mistakes could cause incorrect address derivation or failed/invalid relayer submissions.
> 
> **Overview**
> Adds **Deposit Wallet** support alongside SAFE/PROXY, including deterministic address derivation (`deriveDepositWallet`) and EIP-712 batch signing/request building (`buildDepositWalletBatchRequest`, `buildDepositWalletCreateRequest`).
> 
> Extends `RelayClient` with `deriveDepositWalletAddress()`, `deployDepositWallet()`, and `executeDepositWalletBatch()`, updates `TransactionType` with `WALLET`/`WALLET_CREATE`, and broadens `getDeployed` to accept an optional `type` parameter.
> 
> Updates chain contract config to include deposit wallet factory/implementation addresses (Polygon + Amoy), exports the new builder/ABI surface, bumps package version to `0.0.9`, and adds README + example scripts documenting deposit wallet deploy/execute flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4522e57998501c3f4ff3c4511c41b4ff7c676839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->