### PR TITLE
feat: support RELAYER_API_KEY auth as a first-class constructor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ const client = new RelayClient(relayerUrl, chainId, wallet, builderConfig);
 const proxyClient = new RelayClient(relayerUrl, chainId, wallet, builderConfig, RelayerTxType.PROXY);
 ```
 
+### With Relayer API-Key Authentication
+
+The simplest auth path — uses the `RELAYER_API_KEY` + `RELAYER_API_KEY_ADDRESS` HTTP headers documented at [docs.polymarket.com/trading/gasless](https://docs.polymarket.com/trading/gasless). Obtain the key from polymarket.com's Settings > API Keys; the address is the EOA that owns the key.
+
+```typescript
+import { RelayClient, RelayerTxType } from "@polymarket/builder-relayer-client";
+
+const apiKeyCreds = {
+  apiKey: process.env.RELAYER_API_KEY!,
+  apiKeyAddress: process.env.RELAYER_API_KEY_ADDRESS!,
+};
+
+// Pass `apiKeyCreds` as the 6th constructor argument. The 4th (`builderConfig`)
+// can stay `undefined` — when `apiKeyCreds` is set it takes precedence over
+// any HMAC `BuilderConfig` for authenticated requests.
+const client = new RelayClient(relayerUrl, chainId, wallet, undefined, RelayerTxType.SAFE, apiKeyCreds);
+```
+
 ## Examples
 
 ### Execute ERC20 Approval Transaction

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "test": "make test"
     },
     "devDependencies": {
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
         "@types/chai": "5.2.2",
         "@types/mocha": "10.0.10",
         "@types/node": "^18.7.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
         specifier: ^2.31.4
         version: 2.38.5(typescript@5.9.3)
     devDependencies:
+      '@ethersproject/providers':
+        specifier: 5.8.0
+        version: 5.8.0
+      '@ethersproject/wallet':
+        specifier: 5.8.0
+        version: 5.8.0
       '@types/chai':
         specifier: 5.2.2
         version: 5.2.2

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,7 @@ import {
     OperationType,
     ProxyTransaction,
     ProxyTransactionArgs,
+    RelayerApiKeyCreds,
     RelayerTransaction,
     RelayerTransactionResponse,
     RelayerTxType,
@@ -67,12 +68,15 @@ export class RelayClient {
 
     readonly builderConfig?: BuilderConfig;
 
+    readonly apiKeyCreds?: RelayerApiKeyCreds;
+
     constructor(
         relayerUrl: string,
         chainId: number,
         signer?: Wallet | JsonRpcSigner | WalletClient,
         builderConfig?: BuilderConfig,
         relayTxType?: RelayerTxType,
+        apiKeyCreds?: RelayerApiKeyCreds,
     ) {
         this.relayerUrl = relayerUrl.endsWith("/") ? relayerUrl.slice(0, -1) : relayerUrl;
         this.chainId = chainId;
@@ -82,13 +86,17 @@ export class RelayClient {
         this.relayTxType = relayTxType;
         this.contractConfig = getContractConfig(chainId);
         this.httpClient = new HttpClient();
-        
+
         if (signer != undefined) {
             this.signer = createAbstractSigner(chainId, signer);
         }
 
         if (builderConfig !== undefined) {
             this.builderConfig = builderConfig;
+        }
+
+        if (apiKeyCreds !== undefined) {
+            this.apiKeyCreds = apiKeyCreds;
         }
     }
 
@@ -431,16 +439,35 @@ export class RelayClient {
         method: string,
         path: string,
         body?: string
-    ): Promise<any> {        
+    ): Promise<any> {
+        // API-key auth (preferred when configured) — see
+        // https://docs.polymarket.com/trading/gasless. Empirically required
+        // for CTF `mergePositions` on post-V2-cutover SAFEs: HMAC builder
+        // auth round-trips into STATE_FAILED at gas estimation, while the
+        // API-key path is accepted by the relayer.
+        if (this.canApiKeyAuth()) {
+            return this.send(
+                path,
+                method,
+                {
+                    headers: {
+                        RELAYER_API_KEY: this.apiKeyCreds!.apiKey,
+                        RELAYER_API_KEY_ADDRESS: this.apiKeyCreds!.apiKeyAddress,
+                    },
+                    data: body,
+                }
+            );
+        }
+
         // builders auth
         if (this.canBuilderAuth()) {
             const builderHeaders = await this._generateBuilderHeaders(method, path, body);
             if (builderHeaders !== undefined) {
                 return this.send(
                     path,
-                    method, 
+                    method,
                     { headers: builderHeaders, data: body }
-                );    
+                );
             }
         }
 
@@ -473,6 +500,14 @@ export class RelayClient {
 
     private canBuilderAuth(): boolean {
         return (this.builderConfig != undefined && this.builderConfig.isValid());
+    }
+
+    private canApiKeyAuth(): boolean {
+        return (
+            this.apiKeyCreds != undefined
+            && !!this.apiKeyCreds.apiKey
+            && !!this.apiKeyCreds.apiKeyAddress
+        );
     }
 
     private async send(

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,16 @@ export interface GetDeployedResponse {
     deployed: boolean;
 }
 
+// Auth: simple API-key header path (per
+// https://docs.polymarket.com/trading/gasless). Alternative to HMAC
+// `BuilderConfig` — pass an instance of these to the `RelayClient` constructor
+// to authenticate via `RELAYER_API_KEY` + `RELAYER_API_KEY_ADDRESS` headers.
+// Obtained from polymarket.com Settings > API Keys.
+export interface RelayerApiKeyCreds {
+    apiKey: string;
+    apiKeyAddress: string;
+}
+
 // Deposit Wallet types
 
 export interface DepositWalletCall {


### PR DESCRIPTION
## Summary

Adds the simple API-key header auth path described at [docs.polymarket.com/trading/gasless](https://docs.polymarket.com/trading/gasless) as an opt-in constructor arg (`apiKeyCreds`). When set, `sendAuthedRequest` injects `RELAYER_API_KEY` + `RELAYER_API_KEY_ADDRESS` headers and skips the HMAC `BuilderConfig` path. Backward-compatible: omitting `apiKeyCreds` behaves exactly as today.

## Why

Post-V2 cutover, HMAC-authed `mergePositions` round-trips through the relayer end in `STATE_FAILED` at gas estimation (visible only via direct `GET /transaction/{id}` — the typed SDK swallows the `errorMsg`), while the same calldata + signer using the documented API-key headers succeeds end-to-end (confirmed merge tx [0xe6a49da9…58c588d4](https://polygonscan.com/tx/0xe6a49da92c10d114c8b979788ea068f635a9091d2877fc8d2b50989058c588d4) on test wallet).

Without this PR, consumers that need the API-key path have to either:
- Monkey-patch `sendAuthedRequest` (the method is marked `private` in `.d.ts`, so this requires unsafe casts), or
- Subclass `RelayClient` and override the private method per-instance (same casting problem).

This PR makes it a first-class option, no casts needed.

## Auth precedence

`apiKeyCreds` > `BuilderConfig` > unauthenticated.

If both `apiKeyCreds` and `builderConfig` are passed, the API-key path is used. Matches what most consumers expect — explicit creds win, then any builder, then nothing.

## Changes

- **`src/types.ts`**: new `RelayerApiKeyCreds` interface.
- **`src/client.ts`**: optional `apiKeyCreds` 6th constructor arg + `canApiKeyAuth()` guard + `sendAuthedRequest` precedence update.
- **`README.md`**: new "With Relayer API-Key Authentication" section under the existing builder-auth examples.
- **`package.json`**: add `@ethersproject/{wallet,providers}@5.8.0` as devDependencies. **Pre-existing build fix unrelated to this PR's auth changes** — without them, `pnpm install && make build` on a fresh clone errors on the existing `import { Wallet } from "@ethersproject/wallet"` lines because pnpm's strict isolation doesn't hoist transitive `ethers` sub-packages. Happy to split into a separate PR if preferred.

## Verification

- `pnpm install && pnpm build` clean on a fresh clone with these changes.
- Generated `dist/client.d.ts` exposes the new 6th `apiKeyCreds?: RelayerApiKeyCreds` constructor arg.
- Verified end-to-end against `relayer-v2.polymarket.com` (production) — `mergePositions` from a SAFE-typed proxy lands `STATE_MINED` via the API-key path where HMAC for the same calldata returned `STATE_FAILED`.

## Tests

The existing test suite covers signing / builders. I didn't add client-level tests for the new path because mocking `HttpClient` from the outside is non-trivial in the current harness — happy to add some if you'd like, with guidance on preferred shape.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authentication pathway that changes how requests are authenticated when configured, which could affect relayer interactions and header handling. Backward compatibility is preserved when the new `apiKeyCreds` option is not provided.
> 
> **Overview**
> Adds first-class support for relayer API-key authentication by introducing `RelayerApiKeyCreds` and an optional `apiKeyCreds` constructor arg on `RelayClient`.
> 
> Updates `sendAuthedRequest` to **prefer API-key headers** (`RELAYER_API_KEY` / `RELAYER_API_KEY_ADDRESS`) when present, falling back to existing HMAC `BuilderConfig` auth and then unauthenticated requests.
> 
> Documents the new auth flow in `README.md` and adds `@ethersproject/providers` and `@ethersproject/wallet` as dev dependencies to fix installs under pnpm’s strict dependency isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a02c33b6b03a019b2c16e50fa5b49405c773c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->