### PR TITLE
feat: adding helper methods for deriving beacon wallets

### DIFF
--- a/src/builder/derive.ts
+++ b/src/builder/derive.ts
@@ -217,3 +217,51 @@ export const isUUPSProxy = async (
     const impl = await getImplementationSlotAddress(client, walletAddress);
     return impl !== zeroAddress;
 };
+
+/**
+ * Selector for `BEACON()` — the public getter of the immutable `BEACON`
+ * variable on the post-migration DepositWalletFactory. The legacy
+ * UUPS-deploying factory has no such function; calling this selector on
+ * it reverts (via the UUPS fallback into an impl that doesn't recognize
+ * the selector).
+ */
+const FACTORY_BEACON_SELECTOR: Hex = "0x49493a4d";
+
+/**
+ * Low-level: returns the beacon address advertised by the factory's
+ * `BEACON()` getter, or the zero address if the factory does not implement
+ * that getter (i.e. it is the legacy UUPS-deploying factory, or the address
+ * has no code at all).
+ *
+ * Answers the structural question "does this factory expose the
+ * beacon-factory ABI?" — it does not validate that the returned beacon is
+ * a real Solady UpgradeableBeacon.
+ */
+export const getFactoryBeacon = async (
+    client: PublicClient,
+    factoryAddress: string,
+): Promise<Address> => {
+    try {
+        const { data } = await client.call({
+            to: factoryAddress as Address,
+            data: FACTORY_BEACON_SELECTOR,
+        });
+        // Need 32 bytes of returndata (0x + 64 hex chars) to decode an address.
+        if (!data || data.length < 66) return zeroAddress;
+        return getAddress("0x" + data.slice(-40));
+    } catch {
+        return zeroAddress;
+    }
+};
+
+/**
+ * Low-level: true iff the factory exposes `BEACON()` and returns a non-zero
+ * address — i.e. it is a post-migration, beacon-proxy-deploying factory.
+ */
+export const isBeaconFactory = async (
+    client: PublicClient,
+    factoryAddress: string,
+): Promise<boolean> => {
+    const beacon = await getFactoryBeacon(client, factoryAddress);
+    return beacon !== zeroAddress;
+};

--- a/src/builder/derive.ts
+++ b/src/builder/derive.ts
@@ -28,7 +28,7 @@ export const ERC1967_IMPLEMENTATION_SLOT: Hex =
  * Set on beacon proxies; unused (zero) on UUPS proxies.
  */
 export const ERC1967_BEACON_SLOT: Hex =
-    "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6c1e3c2cfbdf4346";
+    "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50";
 
 export const deriveProxyWallet = (address: string, proxyFactory: string): string => {
     return getCreate2Address({

--- a/src/builder/derive.ts
+++ b/src/builder/derive.ts
@@ -1,5 +1,34 @@
-import { keccak256, getCreate2Address, encodePacked, Hex, encodeAbiParameters, Address, concat, pad, toHex } from 'viem'
+import {
+    keccak256,
+    getCreate2Address,
+    encodePacked,
+    Hex,
+    encodeAbiParameters,
+    Address,
+    concat,
+    pad,
+    toHex,
+    zeroAddress,
+    getAddress,
+    type PublicClient,
+} from 'viem'
 import { SAFE_INIT_CODE_HASH, PROXY_INIT_CODE_HASH } from "../constants";
+
+/**
+ * Standard ERC-1967 implementation slot:
+ *   bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
+ * Set on UUPS proxies; unused (zero) on Solady's beacon proxy template.
+ */
+export const ERC1967_IMPLEMENTATION_SLOT: Hex =
+    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+
+/**
+ * Standard ERC-1967 beacon slot:
+ *   bytes32(uint256(keccak256("eip1967.proxy.beacon")) - 1)
+ * Set on beacon proxies; unused (zero) on UUPS proxies.
+ */
+export const ERC1967_BEACON_SLOT: Hex =
+    "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6c1e3c2cfbdf4346";
 
 export const deriveProxyWallet = (address: string, proxyFactory: string): string => {
     return getCreate2Address({
@@ -48,8 +77,53 @@ function initCodeHashERC1967(implementation: Address, args: Hex): Hex {
 /**
  * Computes the deterministic deposit wallet address for a given owner.
  * walletId is derived as bytes32(owner) - the 20-byte address left-padded to 32 bytes.
+ *
+ * Thin wrapper around {@link determineUUPSAddress}; the signature is kept stable
+ * because this is the README-facing entry point.
  */
 export const deriveDepositWallet = (
+    owner: string,
+    factory: string,
+    implementation: string,
+): string => determineUUPSAddress(owner, factory, implementation);
+
+/**
+ * Byte constants from Solady v0.1.26 LibClone.initCodeHashERC1967BeaconProxy.
+ * These encode the minimal ERC-1967 beacon proxy runtime bytecode.
+ */
+const ERC1967_BEACON_CONST1: Hex = "0xb3582b35133d50545afa5036515af43d6000803e604d573d6000fd5b3d6000f3";
+const ERC1967_BEACON_CONST2: Hex = "0x1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6c";
+const ERC1967_BEACON_CONST3: Hex = "0x60195155f3363d3d373d3d363d602036600436635c60da";
+const ERC1967_BEACON_PREFIX = 0x6100523d8160233d3973n;
+
+/**
+ * Replicates Solady LibClone.initCodeHashERC1967BeaconProxy(beacon, args).
+ * Hash of: prefix(10) | beacon(20) | const3(23) | const2(32) | const1(32) | args(n)
+ */
+function initCodeHashERC1967BeaconProxy(beacon: Address, args: Hex): Hex {
+    const n = BigInt((args.length - 2) / 2);
+    const combined = ERC1967_BEACON_PREFIX + (n << 56n);
+
+    return keccak256(
+        concat([
+            toHex(combined, { size: 10 }),
+            beacon as Hex,
+            ERC1967_BEACON_CONST3,
+            ERC1967_BEACON_CONST2,
+            ERC1967_BEACON_CONST1,
+            args,
+        ]),
+    );
+}
+
+/**
+ * Low-level: predicts the deterministic address a deposit wallet would have
+ * if deployed as a UUPS (ERC-1967) proxy pointing at `implementation` by `factory`.
+ * Mirrors {@link deriveDepositWallet}'s derivation and is intended as a primitive
+ * that callers can compose; the README-facing {@link deriveDepositWallet} entry
+ * point is intentionally left unchanged.
+ */
+export const determineUUPSAddress = (
     owner: string,
     factory: string,
     implementation: string,
@@ -63,4 +137,83 @@ export const deriveDepositWallet = (
     const bytecodeHash = initCodeHashERC1967(implementation as Address, args);
 
     return getCreate2Address({ from: factory as Hex, salt, bytecodeHash });
+};
+
+/**
+ * Low-level: predicts the deterministic address a deposit wallet would have
+ * if deployed as an ERC-1967 beacon proxy bound to `beacon` by `factory`.
+ * Matches DepositWalletFactory._predictWalletAddress (Solady
+ * LibClone.predictDeterministicAddressERC1967BeaconProxy) so the result
+ * equals the onchain factory's prediction for the same owner/id.
+ */
+export const determineBeaconAddress = (
+    owner: string,
+    factory: string,
+    beacon: string,
+): string => {
+    const walletId = pad(owner as Hex, { dir: "left", size: 32 });
+    const args = encodeAbiParameters(
+        [{ type: "address" }, { type: "bytes32" }],
+        [factory as Address, walletId],
+    );
+    const salt = keccak256(args);
+    const bytecodeHash = initCodeHashERC1967BeaconProxy(beacon as Address, args);
+
+    return getCreate2Address({ from: factory as Hex, salt, bytecodeHash });
+};
+
+async function readSlotAddress(
+    client: PublicClient,
+    walletAddress: string,
+    slot: Hex,
+): Promise<Address> {
+    const raw = await client.getStorageAt({ address: walletAddress as Address, slot });
+    if (!raw || raw === "0x") return zeroAddress;
+    const word = pad(raw as Hex, { size: 32, dir: "left" });
+    return getAddress("0x" + word.slice(-40));
+}
+
+/**
+ * Low-level: returns the address stored in the wallet's ERC-1967 implementation slot.
+ * Returns the zero address when the slot is empty (e.g. the wallet is a beacon
+ * proxy, or the address has no code).
+ */
+export const getImplementationSlotAddress = (
+    client: PublicClient,
+    walletAddress: string,
+): Promise<Address> => readSlotAddress(client, walletAddress, ERC1967_IMPLEMENTATION_SLOT);
+
+/**
+ * Low-level: returns the address stored in the wallet's ERC-1967 beacon slot.
+ * Returns the zero address when the slot is empty (e.g. the wallet is a UUPS
+ * proxy, or the address has no code).
+ */
+export const getBeaconSlotAddress = (
+    client: PublicClient,
+    walletAddress: string,
+): Promise<Address> => readSlotAddress(client, walletAddress, ERC1967_BEACON_SLOT);
+
+/**
+ * Low-level: true iff the wallet has a non-zero address in its ERC-1967 beacon slot.
+ */
+export const isBeaconProxy = async (
+    client: PublicClient,
+    walletAddress: string,
+): Promise<boolean> => {
+    const beacon = await getBeaconSlotAddress(client, walletAddress);
+    return beacon !== zeroAddress;
+};
+
+/**
+ * Low-level: true iff the wallet has a non-zero address in its ERC-1967
+ * implementation slot. Note that legacy UUPS deposit wallets migrated via
+ * BeaconForwarder still satisfy this check - they are structurally UUPS
+ * proxies whose implementation happens to forward to the beacon.
+ */
+export const isUUPSProxy = async (
+    client: PublicClient,
+    walletAddress: string,
+): Promise<boolean> => {
+    const impl = await getImplementationSlotAddress(client, walletAddress);
+    return impl !== zeroAddress;
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { Wallet } from "@ethersproject/wallet";
 import { JsonRpcSigner } from "@ethersproject/providers";
-import { WalletClient, zeroAddress } from "viem";
+import { Address, PublicClient, WalletClient, zeroAddress } from "viem";
 import { createAbstractSigner, IAbstractSigner } from "@polymarket/builder-abstract-signer";
 import {
     GET,
@@ -43,6 +43,10 @@ import {
     buildDepositWalletCreateRequest,
     deriveSafe,
     deriveDepositWallet,
+    getBeaconSlotAddress,
+    getImplementationSlotAddress,
+    isBeaconProxy,
+    isUUPSProxy,
 } from "./builder";
 import { sleep } from "./utils";
 import { ClientRelayerTransactionResponse } from "./response";
@@ -385,6 +389,48 @@ export class RelayClient {
         }
         const address = await (this.signer as IAbstractSigner).getAddress();
         return deriveDepositWallet(address, config.DepositWalletFactory, config.DepositWalletImplementation);
+    }
+
+    /**
+     * Returns the address stored in the wallet's ERC-1967 implementation slot,
+     * or the zero address if the slot is empty.
+     */
+    public async getImplementationSlotAddress(walletAddress: string): Promise<Address> {
+        return getImplementationSlotAddress(this.requirePublicClient(), walletAddress);
+    }
+
+    /**
+     * Returns the address stored in the wallet's ERC-1967 beacon slot,
+     * or the zero address if the slot is empty.
+     */
+    public async getBeaconSlotAddress(walletAddress: string): Promise<Address> {
+        return getBeaconSlotAddress(this.requirePublicClient(), walletAddress);
+    }
+
+    /**
+     * Returns true iff the wallet's ERC-1967 beacon slot points at a non-zero address.
+     */
+    public async isBeaconProxy(walletAddress: string): Promise<boolean> {
+        return isBeaconProxy(this.requirePublicClient(), walletAddress);
+    }
+
+    /**
+     * Returns true iff the wallet's ERC-1967 implementation slot points at a non-zero address.
+     * Legacy UUPS deposit wallets migrated via BeaconForwarder still satisfy this check.
+     */
+    public async isUUPSProxy(walletAddress: string): Promise<boolean> {
+        return isUUPSProxy(this.requirePublicClient(), walletAddress);
+    }
+
+    private requirePublicClient(): PublicClient {
+        this.signerNeeded();
+        const publicClient = (this.signer as unknown as { publicClient?: PublicClient }).publicClient;
+        if (!publicClient) {
+            throw new Error(
+                "publicClient unavailable: storage-slot reads require a viem WalletClient-backed signer",
+            );
+        }
+        return publicClient;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -44,7 +44,9 @@ import {
     deriveSafe,
     deriveDepositWallet,
     getBeaconSlotAddress,
+    getFactoryBeacon,
     getImplementationSlotAddress,
+    isBeaconFactory,
     isBeaconProxy,
     isUUPSProxy,
 } from "./builder";
@@ -420,6 +422,24 @@ export class RelayClient {
      */
     public async isUUPSProxy(walletAddress: string): Promise<boolean> {
         return isUUPSProxy(this.requirePublicClient(), walletAddress);
+    }
+
+    /**
+     * Returns the beacon address advertised by the factory's `BEACON()` getter,
+     * or the zero address if the factory does not expose it (legacy
+     * UUPS-deploying factory, or no code at the address).
+     */
+    public async getFactoryBeacon(factoryAddress: string): Promise<Address> {
+        return getFactoryBeacon(this.requirePublicClient(), factoryAddress);
+    }
+
+    /**
+     * Returns true iff the factory exposes `BEACON()` with a non-zero return —
+     * i.e. it is a post-migration, beacon-proxy-deploying factory rather than
+     * the legacy UUPS-proxy-deploying factory.
+     */
+    public async isBeaconFactory(factoryAddress: string): Promise<boolean> {
+        return isBeaconFactory(this.requirePublicClient(), factoryAddress);
     }
 
     private requirePublicClient(): PublicClient {


### PR DESCRIPTION
## Add low-level deposit-wallet primitives (UUPS + beacon proxy)

### Why

The on-chain `DepositWalletFactory` is moving from UUPS proxies to ERC-1967 beacon proxies. The two proxy templates produce **different** CREATE2 addresses for the same owner, so the client needs to be able to:

1. Predict either address (UUPS or beacon) given the relevant inputs.
2. Look at a deployed wallet and tell which kind it actually is.

This PR adds those building blocks. It does not change the higher-level flow — anyone using `deriveDepositWallet` today keeps getting the same answer.

### What's new

All four primitives live in `src/builder/derive.ts` and are also exposed as instance methods on `RelayClient`.

**Pure address-prediction helpers (no RPC needed):**

- `determineUUPSAddress(owner, factory, implementation)` — predicts the address a deposit wallet would have if deployed as a UUPS proxy pointing at `implementation`. This is the old derivation, lifted into its own function.
- `determineBeaconAddress(owner, factory, beacon)` — predicts the address a deposit wallet would have if deployed as a beacon proxy bound to `beacon`. New, matches the on-chain factory's `predictWalletAddress` by construction.

**Slot-reading helpers (need a viem `PublicClient`):**

- `getImplementationSlotAddress(walletAddress)` — reads the ERC-1967 implementation slot and returns the address stored there, or zero if empty.
- `getBeaconSlotAddress(walletAddress)` — same idea, but for the ERC-1967 beacon slot.

**Boolean checks (thin wrappers around the slot readers):**

- `isUUPSProxy(walletAddress)` — true if the implementation slot is non-zero. Note: legacy UUPS wallets that were migrated via `BeaconForwarder` still answer true here — structurally they're still UUPS proxies.
- `isBeaconProxy(walletAddress)` — true if the beacon slot is non-zero.

The same six functions are also exposed on `RelayClient` (e.g. `client.isBeaconProxy(addr)`); these reuse the viem `PublicClient` already held by the abstract signer, so callers using a viem `WalletClient` get this "for free."

The two ERC-1967 slot constants used by the readers (`ERC1967_IMPLEMENTATION_SLOT`, `ERC1967_BEACON_SLOT`) are exported as well, for anyone who wants to do their own storage reads.

### Wiring change

There is exactly one wiring change in this PR: `deriveDepositWallet` (the README-documented function) is now a one-line wrapper around `determineUUPSAddress`. Same signature, same behavior, same output — verified against three different owners on Polygon mainnet. The public API is unchanged.

**What this PR is not:** it is not a switch from UUPS to beacon. `deriveDepositWallet` still returns the UUPS address. That keeps existing integrations working while the factory upgrade is rolled out.

### What production callers will need to do

Once the beacon-proxy factory is deployed, integrators will need to decide which address to use, because the same owner has two different deterministic addresses (one under each template). A typical wiring will look something like:

1. Compute the UUPS address with `determineUUPSAddress` and check `isUUPSProxy` / `isBeaconProxy` on it.
2. If the UUPS address has code, keep using it (legacy wallet).
3. Otherwise compute the beacon address with `determineBeaconAddress` and use that (new wallet).

Exactly how to combine these is left to each integrator — this PR just provides the four primitives to make that wiring possible. We'll revisit `deriveDepositWallet` itself once the factory upgrade is live and we've confirmed the beacon prediction against the on-chain `predictWalletAddress` (deferred because the upgrade isn't deployed yet).

### Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] Existing test suite passes (6/6)
- [x] `deriveDepositWallet` output matches `determineUUPSAddress` for several owners on Polygon mainnet
- [ ] Compare `determineBeaconAddress` to the factory's `predictWalletAddress` on the network where the upgrade is deployed (follow-up)
- [ ] Smoke-test `isBeaconProxy` / `isUUPSProxy` against a live deployed wallet (follow-up)