### PR TITLE
chore: release v0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/builder-relayer-client",
     "description": "Client for Polymarket relayers",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [


### PR DESCRIPTION
## Summary
- Bump @polymarket/builder-relayer-client to 0.0.10 for release

## Verification
- pnpm install --frozen-lockfile
- pnpm test
- pnpm build
- pnpm pack --dry-run

Publishing intentionally left manual.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime or behavioral code changes.
> 
> **Overview**
> Bumps **`@polymarket/builder-relayer-client`** from **0.0.9** to **0.0.10** in `package.json` for a release. No source or API changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01216e648b6e3264bfce20afecfe3086cc874fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->