### PR TITLE
fix: bump axios from ^0.27.2 to ^1.8.4 (two HIGH CVEs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@ethersproject/wallet": "5.8.0",
         "@polymarket/builder-abstract-signer": "0.0.1",
         "@polymarket/builder-signing-sdk": "^0.0.8",
-        "axios": "^0.27.2",
+        "axios": "^1.8.4",
         "browser-or-node": "^3.0.0",
         "ethers": "5.8.0",
         "tsx": "^4.20.3",

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosInstance, AxiosRequestHeaders, AxiosResponse } from "axios";
+// axios@^1.x: AxiosRequestHeaders type narrowed significantly; use Record<string, string> instead.
+import axios, { AxiosInstance, AxiosResponse } from "axios";
 
 export const GET = "GET";
 export const POST = "POST";
@@ -9,7 +10,7 @@ export const PUT = "PUT";
 export type QueryParams = Record<string, any>;
 
 export interface RequestOptions {
-    headers?: AxiosRequestHeaders;
+    headers?: Record<string, string>;
     data?: any;
     params?: QueryParams;
 }
@@ -29,7 +30,7 @@ export class HttpClient {
     ): Promise<AxiosResponse> {
         if (options !== undefined) {
             if (options.headers != undefined) {
-                options.headers["Access-Control-Allow-Credentials"] = true;
+                options.headers["Access-Control-Allow-Credentials"] = "true";
             }
         }
 


### PR DESCRIPTION
## Problem

`@polymarket/builder-relayer-client` depends on `axios@^0.27.2`, which carries two HIGH severity advisories:

| Advisory | Description | Affected |
|---|---|---|
| [GHSA-jr5f-v2jv-69x6](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) | SSRF / credential leakage via absolute URLs | `<0.30.0` |
| [GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433) | DoS via `__proto__` key in `mergeConfig` | `<=0.30.2` |

`axios@^1.8.4` resolves both, plus three additional HIGH advisories on the 1.x line.

## Changes

- **`package.json`**: `"axios": "^0.27.2"` → `"axios": "^1.8.4"`
- **`src/http-helpers/index.ts`**:
  - Remove `AxiosRequestHeaders` import (type changed in 1.x; replaced with `Record<string, string>` for `RequestOptions.headers`)
  - Change header boolean value `true` → string `"true"` (axios 1.x types require string header values)

## Compatibility

All existing API usage (`axios.create`, `instance.request`, `axios.isAxiosError`, `AxiosInstance`, `AxiosResponse`) is unchanged between 0.x and 1.x.

Fixes #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared HTTP client used by relayer requests; changes are small but affect all outbound API calls and dependency security posture.
> 
> **Overview**
> Upgrades **axios** from `^0.27.2` to `^1.8.4` to address known HIGH-severity advisories (SSRF/credential leakage and DoS via `mergeConfig`).
> 
> In **`src/http-helpers/index.ts`**, request header typing is updated for axios 1.x: `RequestOptions.headers` is now `Record<string, string>` instead of `AxiosRequestHeaders`, and `Access-Control-Allow-Credentials` is set to the string `"true"` rather than a boolean. Runtime HTTP usage (`axios.create`, `instance.request`, error handling) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a0d81ac19a8d3ba9cb19a2b0c478b04065887b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->