### PR TITLE
Fix: Upgrade Axios to resolve SSRF, enforce transport type safety, and remove CORS mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@ethersproject/wallet": "5.8.0",
         "@polymarket/builder-abstract-signer": "0.0.1",
         "@polymarket/builder-signing-sdk": "^0.0.8",
-        "axios": "^0.27.2",
+        "axios": "^1.19.0",
         "browser-or-node": "^3.0.0",
         "ethers": "5.8.0",
         "tsx": "^4.20.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
         version: 0.0.1
       '@polymarket/builder-signing-sdk':
         specifier: ^0.0.8
-        version: 0.0.8
+        version: 0.0.8(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       axios:
-        specifier: ^0.27.2
-        version: 0.27.2
+        specifier: ^1.19.0
+        version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       browser-or-node:
         specifier: ^3.0.0
         version: 3.0.0
@@ -62,10 +62,10 @@ importers:
         version: 3.2.25
       jsdom:
         specifier: ^20.0.0
-        version: 20.0.3
+        version: 20.0.3(supports-color@8.1.1)
       jsdom-global:
         specifier: ^3.0.2
-        version: 3.0.2(jsdom@20.0.3)
+        version: 3.0.2(jsdom@20.0.3(supports-color@8.1.1))
       mocha:
         specifier: 9.2.2
         version: 9.2.2
@@ -451,11 +451,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-
-  axios@1.13.0:
-    resolution: {integrity: sha512-zt40Pz4zcRXra9CVV31KeyofwiNvAbJ5B6YPz9pMJ+yOSLikvPT4Yi5LjfgjRa9CawVYBaD1JQzIVcIvBejKeA==}
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -683,8 +680,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -694,6 +691,10 @@ packages:
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs.realpath@1.0.0:
@@ -728,7 +729,7 @@ packages:
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -755,6 +756,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -970,8 +975,9 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -1118,6 +1124,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -1553,13 +1560,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@polymarket/builder-signing-sdk@0.0.8':
+  '@polymarket/builder-signing-sdk@0.0.8(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@types/node': 18.19.130
-      axios: 1.13.0
+      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@scure/base@1.2.6': {}
 
@@ -1613,9 +1621,9 @@ snapshots:
 
   aes-js@3.0.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -1640,20 +1648,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@0.27.2:
+  axios@1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
-
-  axios@1.13.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -1756,9 +1759,11 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decamelize@4.0.0: {}
 
@@ -1911,7 +1916,9 @@ snapshots:
 
   flat@5.0.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   form-data@4.0.4:
     dependencies:
@@ -1919,6 +1926,14 @@ snapshots:
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
+      mime-types: 2.1.35
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs.realpath@1.0.0: {}
@@ -1986,6 +2001,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   he@1.2.0: {}
 
   hmac-drbg@1.0.1:
@@ -1998,18 +2017,18 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2058,11 +2077,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom-global@3.0.2(jsdom@20.0.3):
+  jsdom-global@3.0.2(jsdom@20.0.3(supports-color@8.1.1)):
     dependencies:
-      jsdom: 20.0.3
+      jsdom: 20.0.3(supports-color@8.1.1)
 
-  jsdom@20.0.3:
+  jsdom@20.0.3(supports-color@8.1.1):
     dependencies:
       abab: 2.0.6
       acorn: 8.15.0
@@ -2075,8 +2094,8 @@ snapshots:
       escodegen: 2.1.0
       form-data: 4.0.4
       html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 5.0.0(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.22
       parse5: 7.3.0
@@ -2217,7 +2236,7 @@ snapshots:
 
   process@0.11.10: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   psl@1.15.0:
     dependencies:

--- a/src/client.ts
+++ b/src/client.ts
@@ -140,7 +140,7 @@ export class RelayClient {
     }
 
     public async getNonce(signerAddress: string, signerType: string): Promise<NoncePayload> {
-        return this.send(
+        return this.send<NoncePayload>(
             `${GET_NONCE}`,
             GET,
             {params: { address: signerAddress, type: signerType }},
@@ -148,7 +148,7 @@ export class RelayClient {
     }
 
     public async getRelayPayload(signerAddress: string, signerType: string): Promise<RelayPayload> {
-        return this.send(
+        return this.send<RelayPayload>(
             `${GET_RELAY_PAYLOAD}`,
             GET,
             {params: { address: signerAddress, type: signerType }}
@@ -156,7 +156,7 @@ export class RelayClient {
     }
 
     public async getTransaction(transactionId: string): Promise<RelayerTransaction[]> {
-        return this.send(
+        return this.send<RelayerTransaction[]>(
             `${GET_TRANSACTION}`,
             GET,
             {params: { id: transactionId }},
@@ -164,7 +164,7 @@ export class RelayClient {
     }
 
     public async getTransactions(): Promise<RelayerTransaction[]> {
-        return this.sendAuthedRequest(GET, GET_TRANSACTIONS);
+        return this.sendAuthedRequest<RelayerTransaction[]>(GET, GET_TRANSACTIONS);
     }
 
     /**
@@ -229,7 +229,7 @@ export class RelayClient {
         
         const requestPayload = JSON.stringify(request);
         
-        const resp: RelayerTransactionResponse = await this.sendAuthedRequest(POST, SUBMIT_TRANSACTION, requestPayload)
+        const resp = await this.sendAuthedRequest<RelayerTransactionResponse>(POST, SUBMIT_TRANSACTION, requestPayload)
         return new ClientRelayerTransactionResponse(
             resp.transactionID,
             resp.state,
@@ -276,7 +276,7 @@ export class RelayClient {
         
         const requestPayload = JSON.stringify(request);
         
-        const resp: RelayerTransactionResponse = await this.sendAuthedRequest(POST, SUBMIT_TRANSACTION, requestPayload);
+        const resp = await this.sendAuthedRequest<RelayerTransactionResponse>(POST, SUBMIT_TRANSACTION, requestPayload);
         
         return new ClientRelayerTransactionResponse(
             resp.transactionID,
@@ -324,7 +324,7 @@ export class RelayClient {
         
         const requestPayload = JSON.stringify(request);
 
-        const resp: RelayerTransactionResponse = await this.sendAuthedRequest(POST, SUBMIT_TRANSACTION, requestPayload)
+        const resp = await this.sendAuthedRequest<RelayerTransactionResponse>(POST, SUBMIT_TRANSACTION, requestPayload)
         
         return new ClientRelayerTransactionResponse(
             resp.transactionID,
@@ -339,7 +339,7 @@ export class RelayClient {
         if (type !== undefined) {
             params.type = type;
         }
-        const resp: GetDeployedResponse = await this.send(
+        const resp = await this.send<GetDeployedResponse>(
             `${GET_DEPLOYED}`,
             GET,
             {params},
@@ -363,7 +363,7 @@ export class RelayClient {
         const request = buildDepositWalletCreateRequest(from, depositWalletConfig);
         const requestPayload = JSON.stringify(request);
 
-        const resp: RelayerTransactionResponse = await this.sendAuthedRequest(POST, SUBMIT_TRANSACTION, requestPayload);
+        const resp = await this.sendAuthedRequest<RelayerTransactionResponse>(POST, SUBMIT_TRANSACTION, requestPayload);
         return new ClientRelayerTransactionResponse(
             resp.transactionID,
             resp.state,
@@ -411,7 +411,7 @@ export class RelayClient {
 
         const requestPayload = JSON.stringify(request);
 
-        const resp: RelayerTransactionResponse = await this.sendAuthedRequest(POST, SUBMIT_TRANSACTION, requestPayload);
+        const resp = await this.sendAuthedRequest<RelayerTransactionResponse>(POST, SUBMIT_TRANSACTION, requestPayload);
         return new ClientRelayerTransactionResponse(
             resp.transactionID,
             resp.state,
@@ -502,24 +502,24 @@ export class RelayClient {
         console.log(`Transaction not found or not in given states, timing out!`);
     }
 
-    private async sendAuthedRequest(
+    private async sendAuthedRequest<TResponse>(
         method: string,
         path: string,
         body?: string
-    ): Promise<any> {        
+    ): Promise<TResponse> {
         // builders auth
         if (this.canBuilderAuth()) {
             const builderHeaders = await this._generateBuilderHeaders(method, path, body);
             if (builderHeaders !== undefined) {
-                return this.send(
+                return this.send<TResponse>(
                     path,
-                    method, 
+                    method,
                     { headers: builderHeaders, data: body }
-                );    
+                );
             }
         }
 
-        return this.send(
+        return this.send<TResponse>(
             path,
             method,
             {data: body}
@@ -550,12 +550,12 @@ export class RelayClient {
         return (this.builderConfig != undefined && this.builderConfig.isValid());
     }
 
-    private async send(
+    private async send<TResponse>(
         endpoint: string,
         method: string,
         options?: RequestOptions
-    ): Promise<any> {
-        const resp = await this.httpClient.send(`${this.relayerUrl}${endpoint}`, method, options);
+    ): Promise<TResponse> {
+        const resp = await this.httpClient.send<TResponse>(`${this.relayerUrl}${endpoint}`, method, options);
         return resp.data;
     }
 

--- a/src/http-helpers/index.ts
+++ b/src/http-helpers/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestHeaders, AxiosResponse } from "axios";
+import axios, { AxiosInstance, AxiosResponse } from "axios";
 
 export const GET = "GET";
 export const POST = "POST";
@@ -6,11 +6,11 @@ export const DELETE = "DELETE";
 export const PUT = "PUT";
 
 
-export type QueryParams = Record<string, any>;
+export type QueryParams = Record<string, unknown>;
 
 export interface RequestOptions {
-    headers?: AxiosRequestHeaders;
-    data?: any;
+    headers?: Record<string, string>;
+    data?: unknown;
     params?: QueryParams;
 }
 
@@ -22,19 +22,13 @@ export class HttpClient {
         this.instance = axios.create({withCredentials: true});
     }
 
-    public async send(
+    public async send<TResponse>(
         endpoint: string,
         method: string,
         options?: RequestOptions,
-    ): Promise<AxiosResponse> {
-        if (options !== undefined) {
-            if (options.headers != undefined) {
-                options.headers["Access-Control-Allow-Credentials"] = true;
-            }
-        }
-
+    ): Promise<AxiosResponse<TResponse>> {
         try {
-            const resp = await this.instance.request(
+            const resp = await this.instance.request<TResponse>(
                 {
                     url: endpoint,
                     method: method,
@@ -44,7 +38,7 @@ export class HttpClient {
                 }
             );
             return resp;
-        } catch (err) {
+        } catch (err: unknown) {
             if (axios.isAxiosError(err)) {
                 if (err.response) {
                     const errPayload = {
@@ -61,7 +55,8 @@ export class HttpClient {
                     throw new Error(JSON.stringify(errPayload));
                 }
             }
-            throw new Error(JSON.stringify({ error: err }));
+            const message = err instanceof Error ? err.message : String(err);
+            throw new Error(JSON.stringify({ error: message }));
         }
     }
 }


### PR DESCRIPTION

### Description
This PR addresses a critical supply-chain vulnerability, untyped transport boundaries, and an incorrect CORS header mutation within the `builder-relayer-client` repository.

**Vulnerabilities & Security Defects Remediated:**
* **Dependency / SSRF and Credential Leakage (`package.json`, `pnpm-lock.yaml`):** The runtime dependency on `axios` was previously resolving to a vulnerable `0.x` release. It has been safely upgraded and lock-resolved to `^1.19.0` to eliminate known SSRF and credential leakage advisories while maintaining public client API compatibility.
* **Type Safety / Untyped Transport Boundary (`src/http-helpers/index.ts`, `src/client.ts`):** `QueryParams`, request bodies, and transport responses previously utilized `any`, allowing malformed data to cross the internal HTTP boundary without compiler enforcement. The transport layer now correctly implements `unknown`, strict `Record<string, unknown>` types, and strongly-typed generic `TResponse` results tied to the existing payload contracts (e.g., `NoncePayload`, `RelayPayload`, etc.).
* **HTTP Contract / Incorrect CORS Direction (`src/http-helpers/index.ts`):** The HTTP client erroneously mutated caller-provided request headers by injecting `Access-Control-Allow-Credentials`. Since this is strictly a response-side CORS header and grants no browser permissions on the request side, the mutation has been completely removed. Caller headers are now safely forwarded without unintended side effects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major axios bump on the authenticated relayer HTTP path can change request/error behavior; CORS header removal is small but worth a smoke test of credentialed calls.
> 
> **Overview**
> Upgrades `axios` from `^0.27.2` to `^1.19.0` to pick up a patched HTTP client (SSRF / credential-leakage advisories) and lockfile-resolves related transitives.
> 
> HTTP transport is now generic: `send` / `sendAuthedRequest` take `TResponse` and `RelayClient` call sites pass payload types instead of `any`. Request options drop `any` in favor of `unknown` / `Record<string, string>`.
> 
> Removes the client-side injection of `Access-Control-Allow-Credentials` on outgoing requests (a response-only CORS header). Non-Axios errors stringify the message instead of the raw thrown value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ecb385f25a86f8907448057e291edfca3de0a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->